### PR TITLE
Add comprehensive extraction configuration

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,16 +1,43 @@
 extraction:
+  # Text extraction settings
   min_text_length: 10
   page_separator: "\n\n=== PAGE {} ===\n\n"
 
+  # Table detection
+  table_settings:
+    vertical_strategy: "lines"
+    horizontal_strategy: "lines"
+    edge_min_length: 3
+    min_words_horizontal: 1
+    min_words_vertical: 1
+
+  # RPG-specific patterns
+  stat_block_indicators:
+    - "HP:"
+    - "MP:"
+    - "Defense:"
+    - "M.Defense:"
+    - "Initiative:"
+
 markdown:
+  # Header detection patterns
   chapter_patterns:
-    - "^CHAPTER\s+\d+"
-    - "^Chapter\s+\d+"
+    - "^CHAPTER\\s+\\d+"
+    - "^Chapter\\s+\\d+"
+
   section_patterns:
-    - "^[A-Z][A-Z\s]+$"
+    - "^[A-Z][A-Z\\s]+$"  # All caps headers
+
+  # Conversion rules
+  preserve_formatting:
+    - bold
+    - italic
+    - lists
 
 output:
+  chunk_size_kb: 500  # Split large files
   create_index: true
 
 logging:
   level: INFO
+  file: logs/extraction.log


### PR DESCRIPTION
## Summary
- Expand `config.yaml` to mirror README with table detection, stat-block indicators, markdown formatting rules, and output/index options.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_688deeae6eb48326a32de94d731c103d