### PR TITLE
Implement PDF extraction workflow and CLI

### DIFF
--- a/src/extractor.py
+++ b/src/extractor.py
@@ -1,10 +1,147 @@
-"""Placeholder for PDF extraction logic."""
+#!/usr/bin/env python3
+"""Main extraction orchestrator for Fabula Ultima PDFs."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, Optional
+
+import click
+import yaml
+from loguru import logger
+from tqdm import tqdm
+
+from .markdown_converter import MarkdownConverter
+from .processor import PDFProcessor
+from .utils import get_file_hash, setup_logging, validate_pdf
 
 
-def main():
-    """Entry point for extraction."""
-    pass
+class FabulaExtractor:
+    """Coordinate PDF processing and markdown conversion."""
+
+    def __init__(self, config_path: str = "config.yaml") -> None:
+        self.config = self._load_config(config_path)
+        self.processor = PDFProcessor(self.config)
+        self.converter = MarkdownConverter(self.config)
+        setup_logging(self.config.get("logging"))
+
+    # ------------------------------------------------------------------
+    # Configuration and caching helpers
+    # ------------------------------------------------------------------
+    def _load_config(self, config_path: str) -> Dict:
+        """Load YAML configuration file."""
+        with open(config_path, "r", encoding="utf-8") as fh:
+            return yaml.safe_load(fh)
+
+    def _save_cache(self, cache_path: Path, data: Dict) -> None:
+        """Write raw extraction data to a JSON cache file."""
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        with cache_path.open("w", encoding="utf-8") as fh:
+            json.dump(data, fh)
+
+    def _load_cache(self, cache_path: Path) -> Dict:
+        """Load previously cached extraction data."""
+        with cache_path.open("r", encoding="utf-8") as fh:
+            return json.load(fh)
+
+    # ------------------------------------------------------------------
+    # Extraction methods
+    # ------------------------------------------------------------------
+    def extract_pdf(self, pdf_path: Path) -> Optional[Dict]:
+        """Extract text from a single PDF file."""
+        logger.info(f"Processing: {pdf_path.name}")
+
+        if not validate_pdf(pdf_path):
+            logger.error(f"Invalid PDF: {pdf_path}")
+            return None
+
+        file_hash = get_file_hash(pdf_path)
+        cache_path = Path(f"output/raw/{file_hash}.json")
+
+        if cache_path.exists():
+            logger.info("Using cached extraction")
+            return self._load_cache(cache_path)
+
+        try:
+            result = self.processor.process_pdf(pdf_path)
+            self._save_cache(cache_path, result)
+
+            markdown = self.converter.convert(result)
+            output_path = Path(f"output/markdown/{pdf_path.stem}.md")
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_text(markdown, encoding="utf-8")
+
+            logger.success(f"Saved: {output_path}")
+            return result
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logger.exception(f"Failed to process {pdf_path}: {exc}")
+            return None
+
+    def extract_all(self, pdf_dir: Path = Path("input/pdfs")) -> Dict:
+        """Extract all PDF files in ``pdf_dir``."""
+        pdf_files = list(pdf_dir.glob("*.pdf"))
+        if not pdf_files:
+            logger.error(f"No PDFs found in {pdf_dir}")
+            return {}
+
+        logger.info(f"Found {len(pdf_files)} PDFs")
+        results: Dict[str, Dict] = {}
+
+        with tqdm(pdf_files, desc="Extracting PDFs") as bar:
+            for pdf_path in bar:
+                bar.set_description(f"Processing {pdf_path.name}")
+                result = self.extract_pdf(pdf_path)
+                if result is not None:
+                    results[pdf_path.name] = result
+
+        if self.config.get("output", {}).get("create_index"):
+            self._create_index(results)
+
+        return results
+
+    # ------------------------------------------------------------------
+    # Output helpers
+    # ------------------------------------------------------------------
+    def _create_index(self, results: Dict) -> None:
+        """Create an index markdown file summarising results."""
+        index_path = Path("output/markdown/INDEX.md")
+        lines = ["# Fabula Ultima Content Index\n\n"]
+        for filename, data in results.items():
+            lines.append(f"## {filename}\n")
+            lines.append(f"- Pages: {data.get('total_pages', 0)}\n")
+            lines.append(f"- Text blocks: {data.get('text_blocks', 0)}\n")
+            lines.append(f"- Tables: {data.get('tables', 0)}\n")
+            lines.append(
+                f"- File: [{filename}](./{Path(filename).stem}.md)\n\n"
+            )
+
+        index_path.parent.mkdir(parents=True, exist_ok=True)
+        index_path.write_text("".join(lines), encoding="utf-8")
+        logger.info("Created index file")
 
 
-if __name__ == "__main__":
+@click.command()
+@click.option("--pdf", type=click.Path(exists=True), help="Single PDF to process")
+@click.option(
+    "--all",
+    "process_all",
+    is_flag=True,
+    help="Process all PDFs in input directory",
+)
+@click.option("--config", default="config.yaml", help="Config file path")
+def main(pdf: Optional[str], process_all: bool, config: str) -> None:
+    """Fabula Ultima PDF Text Extractor."""
+    extractor = FabulaExtractor(config)
+
+    if pdf:
+        extractor.extract_pdf(Path(pdf))
+    elif process_all:
+        extractor.extract_all()
+    else:
+        extractor.extract_all()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
     main()
+

--- a/src/markdown_converter.py
+++ b/src/markdown_converter.py
@@ -1,9 +1,17 @@
 """Placeholder for markdown conversion utilities."""
 
+from __future__ import annotations
+
+from typing import Dict, Any
+
 
 class MarkdownConverter:
     """Stub markdown converter."""
 
-    def convert(self, data):
+    def __init__(self, config: Dict | None = None) -> None:
+        self.config = config or {}
+
+    def convert(self, data: Any) -> str:
         """Convert extracted data to markdown (placeholder)."""
         return ""
+

--- a/src/processor.py
+++ b/src/processor.py
@@ -1,9 +1,17 @@
 """Placeholder for PDF processing utilities."""
 
+from __future__ import annotations
+
+from typing import Dict, Any
+
 
 class PDFProcessor:
-    """Stub processor class."""
+    """Stub processor class used in tests."""
 
-    def process_pdf(self, pdf_path):
+    def __init__(self, config: Dict | None = None) -> None:
+        self.config = config or {}
+
+    def process_pdf(self, pdf_path: Any) -> Dict:
         """Process a PDF file (placeholder)."""
         return {}
+

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,16 +1,37 @@
 """Utility helpers for the extractor project."""
 
+from __future__ import annotations
 
-def setup_logging(config=None):
-    """Placeholder logging setup."""
-    pass
+import hashlib
+import sys
+from pathlib import Path
+from typing import Optional
+
+from loguru import logger
 
 
-def validate_pdf(pdf_path):
-    """Placeholder PDF validation."""
-    return True
+def setup_logging(config: Optional[dict] = None) -> None:
+    """Configure basic logging using loguru."""
+    config = config or {}
+    level = config.get("level", "INFO")
+
+    logger.remove()
+    logger.add(sys.stderr, level=level)
+
+    logfile = config.get("file")
+    if logfile:
+        log_path = Path(logfile)
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        logger.add(log_path, level=level)
 
 
-def get_file_hash(pdf_path):
-    """Placeholder hashing helper."""
-    return ""
+def validate_pdf(pdf_path: Path) -> bool:
+    """Simple PDF file validation."""
+    return pdf_path.exists() and pdf_path.suffix.lower() == ".pdf"
+
+
+def get_file_hash(pdf_path: Path) -> str:
+    """Return a SHA256 hash of ``pdf_path``'s contents."""
+    data = pdf_path.read_bytes()
+    return hashlib.sha256(data).hexdigest()
+

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -1,6 +1,69 @@
-"""Placeholder tests for the extractor."""
+"""Tests for :mod:`src.extractor`."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from src.extractor import FabulaExtractor
 
 
-def test_placeholder():
-    """Simple placeholder test."""
-    assert True
+def _root_config() -> Path:
+    return Path(__file__).resolve().parent.parent / "config.yaml"
+
+
+def test_extract_pdf_and_cache(tmp_path, monkeypatch):
+    """Processing a PDF should create markdown and cache files."""
+    monkeypatch.chdir(tmp_path)
+
+    pdf_path = Path("sample.pdf")
+    pdf_path.write_bytes(b"fake pdf data")
+
+    extractor = FabulaExtractor(str(_root_config()))
+    extractor.extract_pdf(pdf_path)
+
+    md_path = tmp_path / "output" / "markdown" / "sample.md"
+    assert md_path.exists()
+
+    cache_dir = tmp_path / "output" / "raw"
+    cache_files = list(cache_dir.glob("*.json"))
+    assert cache_files
+    cached_content = json.loads(cache_files[0].read_text())
+
+    # Replace processor to ensure cached data is used on second run
+    call_count = 0
+
+    def fake_process(_):
+        nonlocal call_count
+        call_count += 1
+        return {"total_pages": 2}
+
+    extractor.processor.process_pdf = fake_process
+    result = extractor.extract_pdf(pdf_path)
+
+    assert call_count == 0  # cache hit, processor not called
+    assert result == cached_content
+
+
+def test_extract_all_creates_index(tmp_path, monkeypatch):
+    """``extract_all`` should generate an index file."""
+    monkeypatch.chdir(tmp_path)
+
+    pdf_dir = Path("input/pdfs")
+    pdf_dir.mkdir(parents=True)
+    (pdf_dir / "a.pdf").write_bytes(b"a")
+    (pdf_dir / "b.pdf").write_bytes(b"b")
+
+    extractor = FabulaExtractor(str(_root_config()))
+
+    def fake_process(_):
+        return {"total_pages": 1, "text_blocks": 1, "tables": 0}
+
+    extractor.processor.process_pdf = fake_process
+    extractor.extract_all(pdf_dir)
+
+    index_path = Path("output/markdown/INDEX.md")
+    assert index_path.exists()
+    content = index_path.read_text()
+    assert "a.pdf" in content and "b.pdf" in content
+


### PR DESCRIPTION
## Summary
- add `FabulaExtractor` class with config loading, caching, markdown conversion, and index generation
- implement CLI with click for single PDFs or bulk extraction
- provide utility helpers for logging, PDF validation, and file hashing
- add tests covering caching and index creation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688df04fb4748326a63418478ac7755f