### PR TITLE
Add end-to-end extraction tests with fixture PDF

### DIFF
--- a/tests/fixtures/sample.pdf
+++ b/tests/fixtures/sample.pdf
@@ -1,0 +1,68 @@
+%PDF-1.3
+% ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/Contents 7 0 R /MediaBox [ 0 0 612 792 ] /Parent 6 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+4 0 obj
+<<
+/PageMode /UseNone /Pages 6 0 R /Type /Catalog
+>>
+endobj
+5 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20250802112355+00'00') /Creator (ReportLab PDF Library - www.reportlab.com) /Keywords () /ModDate (D:20250802112355+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+6 0 obj
+<<
+/Count 1 /Kids [ 3 0 R ] /Type /Pages
+>>
+endobj
+7 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 105
+>>
+stream
+GapQh0E=F,0U\H3T\pNYT^QKk?tc>IP,;W#U1^23ihPEM_?CW4KISi90MjG^2,FS#<RC5+c,n(/.*jQh8^UKCa\iDl!\%1.!WX5a'2e~>endstream
+endobj
+xref
+0 8
+0000000000 65535 f 
+0000000073 00000 n 
+0000000104 00000 n 
+0000000211 00000 n 
+0000000404 00000 n 
+0000000472 00000 n 
+0000000768 00000 n 
+0000000827 00000 n 
+trailer
+<<
+/ID 
+[<8a9cf5d21ce76fb2c5086a9dfd5b58a9><8a9cf5d21ce76fb2c5086a9dfd5b58a9>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 5 0 R
+/Root 4 0 R
+/Size 8
+>>
+startxref
+1022
+%%EOF


### PR DESCRIPTION
## Summary
- add sample PDF fixture for tests
- cover cache reuse in `extract_pdf`
- verify index generation in `extract_all`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_688df4bd375883269223562d15e69027