### PR TITLE
refactor: use Path joins for file paths

### DIFF
--- a/src/fabula_extractor/extractor.py
+++ b/src/fabula_extractor/extractor.py
@@ -52,7 +52,7 @@ class FabulaExtractor:
             return None
 
         file_hash = get_file_hash(pdf_path)
-        cache_path = Path(f"output/raw/{file_hash}.json")
+        cache_path = Path("output") / "raw" / f"{file_hash}.json"
 
         if cache_path.exists():
             logger.info("Using cached extraction")
@@ -63,7 +63,7 @@ class FabulaExtractor:
             save_cache(cache_path, result)
 
             markdown = self.converter.convert(result)
-            output_path = Path(f"output/markdown/{pdf_path.stem}.md")
+            output_path = Path("output") / "markdown" / f"{pdf_path.stem}.md"
             output_path.parent.mkdir(parents=True, exist_ok=True)
             output_path.write_text(markdown, encoding="utf-8")
 
@@ -73,7 +73,7 @@ class FabulaExtractor:
             logger.exception(f"Failed to process {pdf_path}: {exc}")
             return None
 
-    def extract_all(self, pdf_dir: Path = Path("input/pdfs")) -> Dict:
+    def extract_all(self, pdf_dir: Path = Path("input") / "pdfs") -> Dict:
         """Extract all PDF files in ``pdf_dir``."""
         pdf_files = list(pdf_dir.glob("*.pdf"))
         if not pdf_files:
@@ -100,16 +100,15 @@ class FabulaExtractor:
     # ------------------------------------------------------------------
     def _create_index(self, results: Dict) -> None:
         """Create an index markdown file summarising results."""
-        index_path = Path("output/markdown/INDEX.md")
+        index_path = Path("output") / "markdown" / "INDEX.md"
         lines = ["# Fabula Ultima Content Index\n\n"]
         for filename, data in results.items():
             lines.append(f"## {filename}\n")
             lines.append(f"- Pages: {data.get('total_pages', 0)}\n")
             lines.append(f"- Text blocks: {data.get('text_blocks', 0)}\n")
             lines.append(f"- Tables: {data.get('tables', 0)}\n")
-            lines.append(
-                f"- File: [{filename}](./{Path(filename).stem}.md)\n\n"
-            )
+            link_path = Path(".") / f"{Path(filename).stem}.md"
+            lines.append(f"- File: [{filename}]({link_path})\n\n")
 
         index_path.parent.mkdir(parents=True, exist_ok=True)
         index_path.write_text("".join(lines), encoding="utf-8")

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -68,7 +68,7 @@ def test_extract_all_creates_index(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
 
     fixture = Path(__file__).parent / "fixtures" / "sample.pdf"
-    pdf_dir = Path("input/pdfs")
+    pdf_dir = Path("input") / "pdfs"
     pdf_dir.mkdir(parents=True)
     for name in ("a.pdf", "b.pdf"):
         (pdf_dir / name).write_bytes(fixture.read_bytes())
@@ -81,7 +81,7 @@ def test_extract_all_creates_index(tmp_path, monkeypatch):
     extractor.processor.process_pdf = fake_process
     extractor.extract_all(pdf_dir)
 
-    index_path = Path("output/markdown/INDEX.md")
+    index_path = Path("output") / "markdown" / "INDEX.md"
     assert index_path.exists()
     content = index_path.read_text()
     assert "a.pdf" in content and "b.pdf" in content


### PR DESCRIPTION
## Summary
- build cache and markdown paths with pathlib joins
- use Path joins for input directory and index file generation
- update tests to match new Path handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_688dfb80f4608326ad585a62af2c3aeb