### PR TITLE
Log and test PDF processing failures

### DIFF
--- a/src/fabula_extractor/processor.py
+++ b/src/fabula_extractor/processor.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Dict, List
 
+from loguru import logger
 import fitz  # type: ignore
 import pdfplumber
 
@@ -84,10 +85,10 @@ class PDFProcessor:
                     result["tables"] += len(tables)
 
                     result["pages"].append(page_info)
-        except Exception:
+        except Exception as exc:
             # In case of an invalid PDF or parsing error we simply return
             # whatever has been collected so far.  The calling code can
             # handle empty results and still cache the placeholder data.
-            pass
+            logger.exception(f"Error processing PDF {pdf_path}: {exc}")
 
         return result

--- a/tests/test_processor_logging.py
+++ b/tests/test_processor_logging.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from io import StringIO
+
+from loguru import logger
+from fabula_extractor.processor import PDFProcessor
+
+
+def test_invalid_pdf_logs_error(tmp_path):
+    invalid_pdf = tmp_path / "invalid.pdf"
+    invalid_pdf.write_text("not a pdf")
+
+    processor = PDFProcessor()
+
+    sink = StringIO()
+    handler_id = logger.add(sink, level="ERROR")
+    processor.process_pdf(invalid_pdf)
+    logger.remove(handler_id)
+
+    output = sink.getvalue()
+    assert "Error processing PDF" in output
+    assert str(invalid_pdf) in output


### PR DESCRIPTION
## Summary
- log PDF processing errors with loguru
- add regression test ensuring logging for invalid PDFs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_688f46e797d88326b5d9abce9ef6e499