### PR TITLE
Validate PDF header and add tests

### DIFF
--- a/src/fabula_extractor/utils.py
+++ b/src/fabula_extractor/utils.py
@@ -27,13 +27,20 @@ def setup_logging(config: Optional[dict] = None) -> None:
 
 
 def validate_pdf(path: Path) -> bool:
-    """Check that ``path`` is an existing, readable PDF file."""
+    """Check that ``path`` is an existing, readable PDF file.
+
+    Validates that the file exists, has a ``.pdf`` extension, is readable,
+    and begins with the standard ``%PDF`` header.
+    """
     pdf_path = Path(path)
     if not pdf_path.exists() or pdf_path.suffix.lower() != ".pdf":
         return False
     try:
-        with pdf_path.open("rb"):
-            return True
+        with pdf_path.open("rb") as fh:
+            header = fh.read(4)
+            if not header.startswith(b"%PDF"):
+                return False
+        return True
     except OSError:
         return False
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,27 @@
+"""Tests for :mod:`fabula_extractor.utils`."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from fabula_extractor.utils import validate_pdf
+
+
+def test_validate_pdf_accepts_valid_pdf():
+    """A real PDF should be accepted."""
+    fixture = Path(__file__).parent / "fixtures" / "sample.pdf"
+    assert validate_pdf(fixture)
+
+
+def test_validate_pdf_rejects_text_file(tmp_path):
+    """Files without a PDF extension should be rejected."""
+    txt_file = tmp_path / "file.txt"
+    txt_file.write_text("just some text")
+    assert not validate_pdf(txt_file)
+
+
+def test_validate_pdf_rejects_invalid_header(tmp_path):
+    """A ``.pdf`` file without the ``%PDF`` header should be rejected."""
+    fake_pdf = tmp_path / "fake.pdf"
+    fake_pdf.write_text("not really a pdf")
+    assert not validate_pdf(fake_pdf)


### PR DESCRIPTION
## Summary
- ensure `validate_pdf` checks for `%PDF` header bytes before accepting a file
- add tests for valid PDFs, wrong extensions, and invalid headers

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_688f485fe33483269b99be6d47a75fb9