### PR TITLE
Gracefully handle config load errors

### DIFF
--- a/src/fabula_extractor/extractor.py
+++ b/src/fabula_extractor/extractor.py
@@ -36,8 +36,17 @@ class FabulaExtractor:
     # ------------------------------------------------------------------
     def _load_config(self, config_path: str) -> Dict:
         """Load YAML configuration file."""
-        with open(config_path, "r", encoding="utf-8") as fh:
-            return yaml.safe_load(fh)
+        try:
+            with open(config_path, "r", encoding="utf-8") as fh:
+                return yaml.safe_load(fh) or {}
+        except FileNotFoundError:
+            logger.error(f"Config file not found: {config_path}. Using defaults.")
+            return {}
+        except yaml.YAMLError as exc:
+            logger.error(f"Invalid YAML in config file {config_path}: {exc}")
+            raise ValueError(
+                f"Invalid YAML in configuration file: {config_path}"
+            ) from exc
 
 
     # ------------------------------------------------------------------

--- a/tests/test_config_loading.py
+++ b/tests/test_config_loading.py
@@ -1,0 +1,49 @@
+"""Tests for configuration loading in :mod:`fabula_extractor.extractor`."""
+
+from __future__ import annotations
+
+from io import StringIO
+from pathlib import Path
+
+import pytest
+from loguru import logger
+
+from fabula_extractor.extractor import FabulaExtractor
+
+
+def test_missing_config_uses_defaults(tmp_path):
+    missing = tmp_path / "missing.yaml"
+    sink = StringIO()
+    handler_id = logger.add(sink, level="ERROR")
+
+    extractor = FabulaExtractor(str(missing))
+
+    try:
+        logger.remove(handler_id)
+    except ValueError:
+        pass
+    output = sink.getvalue()
+
+    assert extractor.config == {}
+    assert "Config file not found" in output
+    assert str(missing) in output
+
+
+def test_bad_yaml_raises_value_error(tmp_path):
+    bad = tmp_path / "bad.yaml"
+    bad.write_text("bad: [unclosed")
+
+    sink = StringIO()
+    handler_id = logger.add(sink, level="ERROR")
+
+    with pytest.raises(ValueError):
+        FabulaExtractor(str(bad))
+
+    try:
+        logger.remove(handler_id)
+    except ValueError:
+        pass
+    output = sink.getvalue()
+
+    assert "Invalid YAML" in output
+    assert str(bad) in output


### PR DESCRIPTION
## Summary
- log and handle missing or invalid YAML configuration files
- add tests covering missing paths and malformed config data

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6891da94dc308326b7f2c55f1c11a11c