### PR TITLE
Add unit tests for Markdown conversion and utilities

### DIFF
--- a/tests/test_markdown_converter.py
+++ b/tests/test_markdown_converter.py
@@ -1,0 +1,65 @@
+"""Tests for :mod:`fabula_extractor.markdown_converter`."""
+
+from __future__ import annotations
+
+from fabula_extractor.markdown_converter import MarkdownConverter
+
+
+# ---------------------------------------------------------------------------
+# _apply_formatting
+
+def test_apply_formatting_strips_all_by_default():
+    """Without preservation options all markers should be removed."""
+    conv = MarkdownConverter()
+    line = "\u2022 **bold** *italic*"
+    assert conv._apply_formatting(line) == "bold italic"
+
+
+def test_apply_formatting_preserves_lists():
+    """Bullet characters become markdown lists when preserving lists."""
+    conv = MarkdownConverter({"markdown": {"preserve_formatting": ["lists"]}})
+    assert conv._apply_formatting("\u2022 item") == "- item"
+
+
+def test_apply_formatting_preserves_only_bold():
+    """Bold markers can be preserved independently of italics."""
+    conf = {"markdown": {"preserve_formatting": ["bold"]}}
+    conv = MarkdownConverter(conf)
+    line = "**bold** _italic_"
+    assert conv._apply_formatting(line) == "**bold** italic"
+
+
+def test_apply_formatting_preserves_only_italic():
+    """Italic markers can be preserved while bold is stripped."""
+    conf = {"markdown": {"preserve_formatting": ["italic"]}}
+    conv = MarkdownConverter(conf)
+    line = "__bold__ *italic*"
+    assert conv._apply_formatting(line) == "bold *italic*"
+
+
+# ---------------------------------------------------------------------------
+# _chunk_text
+
+def test_chunk_text_returns_single_chunk_when_size_zero():
+    conv = MarkdownConverter({"output": {"chunk_size_kb": 0}})
+    text = "hello world"
+    assert conv._chunk_text(text) == [text]
+
+
+def test_chunk_text_splits_long_text():
+    conv = MarkdownConverter({"output": {"chunk_size_kb": 1}})
+    text = "a" * 1500
+    chunks = conv._chunk_text(text)
+    assert len(chunks) == 2
+    assert chunks[0] == "a" * 1024
+    assert chunks[1] == "a" * 476
+
+
+def test_chunk_text_handles_multibyte_characters():
+    conv = MarkdownConverter({"output": {"chunk_size_kb": 1}})
+    text = "\U0001F600" * 300  # 300 grinning face emojis
+    chunks = conv._chunk_text(text)
+    assert len(chunks) == 2
+    assert len(chunks[0]) == 256  # 256 * 4 bytes == 1024
+    assert len(chunks[1]) == 44
+    assert "".join(chunks) == text

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,9 +2,15 @@
 
 from __future__ import annotations
 
+import hashlib
 from pathlib import Path
 
-from fabula_extractor.utils import validate_pdf
+from fabula_extractor.utils import (
+    get_file_hash,
+    load_cache,
+    save_cache,
+    validate_pdf,
+)
 
 
 def test_validate_pdf_accepts_valid_pdf():
@@ -25,3 +31,26 @@ def test_validate_pdf_rejects_invalid_header(tmp_path):
     fake_pdf = tmp_path / "fake.pdf"
     fake_pdf.write_text("not really a pdf")
     assert not validate_pdf(fake_pdf)
+
+
+def test_validate_pdf_handles_missing_file(tmp_path):
+    """Non-existent files should return ``False``."""
+    missing = tmp_path / "missing.pdf"
+    assert not validate_pdf(missing)
+
+
+def test_get_file_hash_matches_hashlib(tmp_path):
+    """``get_file_hash`` should return the SHA256 digest of a file."""
+    data_file = tmp_path / "data.bin"
+    data = b"hello world"
+    data_file.write_bytes(data)
+    expected = hashlib.sha256(data).hexdigest()
+    assert get_file_hash(data_file) == expected
+
+
+def test_save_and_load_cache_roundtrip(tmp_path):
+    """Data saved with ``save_cache`` should load back the same."""
+    cache_path = tmp_path / "cache.json"
+    payload = {"a": 1, "b": "two"}
+    save_cache(cache_path, payload)
+    assert load_cache(cache_path) == payload


### PR DESCRIPTION
## Summary
- cover MarkdownConverter formatting options and chunking logic
- test utility helpers like `validate_pdf`, `get_file_hash`, and cache functions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6891dd6a29108326af3066b088f3c892