### PR TITLE
Handle missing setuptools in setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,24 @@
 
 from pathlib import Path
 
-from setuptools import find_packages, setup
+try:
+    from setuptools import find_packages, setup
+except ModuleNotFoundError:
+    import ensurepip
+    import subprocess
+    import sys
+
+    ensurepip.bootstrap()
+    subprocess.check_call([
+        sys.executable,
+        "-m",
+        "pip",
+        "install",
+        "--upgrade",
+        "pip",
+        "setuptools",
+    ])
+    from setuptools import find_packages, setup
 
 
 def _read_requirements() -> list[str]:


### PR DESCRIPTION
## Summary
- Bootstrap setuptools installation when missing and retry import

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689200e752488326aaca5d33d81f4961