### PR TITLE
chore: update PyMuPDF requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ ls output/markdown/
 
 ### requirements.txt
 ```
-PyMuPDF==1.23.8
+PyMuPDF>=1.26.3
 pdfplumber==0.10.3
 pypdf==3.17.1
 pyyaml==6.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Pinned dependencies as documented in README
-PyMuPDF==1.23.8
+PyMuPDF>=1.26.3
 pdfplumber==0.10.3
 pypdf==3.17.1
 pyyaml==6.0.1


### PR DESCRIPTION
## Summary
- relax PyMuPDF to >=1.26.3 for cp39-abi3 wheel support
- document updated PyMuPDF requirement in README

## Testing
- `pip install -r requirements.txt`
- `pytest`
- `python -m fabula_extractor.extractor --pdf tests/fixtures/sample.pdf`


------
https://chatgpt.com/codex/tasks/task_b_68921b6b7b1883268d014cce781f03ae