### PR TITLE
Handle PyMuPDF import fallback for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ venv\Scripts\activate        # Windows
 
 # Install dependencies
 pip install -r requirements.txt
+
+# On Windows ensure PyMuPDF is installed:
+python -m pip install --upgrade pip
+pip install pymupdf
 ```
 
 ## Project Structure

--- a/src/fabula_extractor/processor.py
+++ b/src/fabula_extractor/processor.py
@@ -13,7 +13,15 @@ from pathlib import Path
 from typing import Any, Dict, List
 
 from loguru import logger
-import fitz  # type: ignore
+
+try:
+    import fitz  # type: ignore
+except ModuleNotFoundError:
+    try:
+        import pymupdf as fitz  # type: ignore
+    except ModuleNotFoundError as exc:
+        raise ImportError("PyMuPDF is required; install with 'pip install pymupdf'") from exc
+
 import pdfplumber
 
 


### PR DESCRIPTION
## Summary
- add fallback import for PyMuPDF or pymupdf with clear error message
- document Windows steps to install PyMuPDF in README

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68921d8990f483268875586f77bee58b