### PR TITLE
Final review for errors and bugs

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,7 +1,6 @@
 extraction:
   # Text extraction settings
   min_text_length: 10
-  page_separator: "\n\n=== PAGE {} ===\n\n"
 
   # Reading order settings
   sort_blocks: true              # Sort text blocks by reading order

--- a/src/pdf_extractor/errors.py
+++ b/src/pdf_extractor/errors.py
@@ -270,5 +270,5 @@ def get_friendly_message(error: Exception, context: Optional[dict] = None) -> st
             f"  -> {str(error)[:200]}\n\n"
             "Hint: Check the log file (logs/extraction.log) for more details. "
             "If the problem persists, please report it at:\n"
-            "  https://github.com/anthropics/pdf-extractor/issues"
+            "  https://github.com/silentArtifact/TTRPG-PDF-Text-Extractor/issues"
         )

--- a/src/pdf_extractor/presets.py
+++ b/src/pdf_extractor/presets.py
@@ -8,6 +8,7 @@ use case.
 
 from __future__ import annotations
 
+import copy
 from typing import Any, Dict
 
 # Simple preset: Fast extraction with minimal processing
@@ -15,7 +16,6 @@ from typing import Any, Dict
 PRESET_SIMPLE: Dict[str, Any] = {
     "extraction": {
         "min_text_length": 10,
-        "page_separator": "\n\n---\n\n",
         "sort_blocks": False,
         "column_threshold": 0.3,
         "detect_headers_footers": False,
@@ -55,7 +55,6 @@ PRESET_SIMPLE: Dict[str, Any] = {
 PRESET_DETAILED: Dict[str, Any] = {
     "extraction": {
         "min_text_length": 10,
-        "page_separator": "\n\n=== PAGE {} ===\n\n",
         "sort_blocks": True,
         "column_threshold": 0.3,
         "detect_headers_footers": True,
@@ -103,7 +102,6 @@ PRESET_DETAILED: Dict[str, Any] = {
 PRESET_TABLES: Dict[str, Any] = {
     "extraction": {
         "min_text_length": 5,
-        "page_separator": "\n\n---\n\n",
         "sort_blocks": True,
         "column_threshold": 0.3,
         "detect_headers_footers": True,
@@ -178,7 +176,7 @@ def get_preset(name: str) -> Dict[str, Any]:
     if name_lower not in PRESETS:
         available = ", ".join(PRESETS.keys())
         raise ValueError(f"Unknown preset '{name}'. Available presets: {available}")
-    return PRESETS[name_lower].copy()
+    return copy.deepcopy(PRESETS[name_lower])
 
 
 def list_presets() -> Dict[str, str]:


### PR DESCRIPTION
- Fix get_preset() returning shallow copy (nested dict mutations affected original preset data) - now uses copy.deepcopy()
- Update placeholder GitHub issues URL to correct repository
- Remove unused page_separator config option from presets and config.yaml